### PR TITLE
Delete AUTHORS

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,3 +1,0 @@
-# This is the official list of shipped authors for copyright purposes.
-
-Zach Latta <zach@hackclub.io>


### PR DESCRIPTION
#47 made this repository copyright Hack Club instead of copyright the people listed in `AUTHORS`. This PR removes the now redundant `AUTHORS` file.
